### PR TITLE
Changing research board to editorial board

### DIFF
--- a/docs/blog/.authors.yml
+++ b/docs/blog/.authors.yml
@@ -1,21 +1,21 @@
 authors:
   taddyb:
     name: Tadd Bindas
-    description: Board Member
+    description: Editoral Board Member
     avatar: https://github.com/taddyb.png
   jmframe:
     name: Jonathan Frame
-    description: Board Member
+    description: Editoral Board Member
     avatar: https://github.com/jmframe.png
   rappjer1:
     name: Jeremy Rapp
-    description: Board Member
+    description: Editoral Board Member
     avatar: https://github.com/rappjer1.png
   RY4GIT:
     name: Ryoko Araki
-    description: Board Member
+    description: Editoral Board Member
     avatar: https://github.com/RY4GIT.png
   soelemaafnan:
     name: Soelem Aafnan Bhuiyan
-    description: Board Member
+    description: Editoral Board Member
     avatar: https://github.com/soelemaafnan.png

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 DeepGroundwater was inspired from the idea that not all research belongs on academic journals. There is great work done by students, postdocs, and research leads that may not advance the science, but deserves to be shared with the community. Furthermore, the peer-review process often can take weeks, if not months, for a paper to make it from draft to published. There is a need for a site to share developing reserach, and code, with others to spurn discovery and novelty; and we at Deep Groundwater hope we can provide that here. 
 
-## Research Board
+## Editorial Board
 
 DeepGroundwater is managed by the following maintainers:
 
@@ -15,4 +15,44 @@ DeepGroundwater is managed by the following maintainers:
 - Soelem Aafnan Bhuiyan
 
 ## Contributions
-We welcome contributions from students, professors and industry professionals in the broad range of research related to hydrology and water resources. Contributions should be made by a GitHub pull request. An editorial review is required from at least two members of the board. Note that our editorial review is intended to ensure that the contribution is on brand for DeepGroundWater, and is not intended to ensure scientific rigor. 
+
+We welcome contributions from students, professors and industry professionals in the broad range of research related to hydrology and water resources. Contributions should be made by a GitHub pull request. An editorial review is required from at least two members of the board. 
+
+*Note that our editorial review is intended to ensure that the contribution is on brand for DeepGroundWater and the markdown formatting works with MkDocs, and is not intended to ensure scientific rigor.*
+
+### How to contribute
+
+1. Fork the [DeepGroundwater github website](https://github.com/DeepGroundwater/DeepGroundwater.github.io)
+2. Run the following commands to install mkdocs to your env
+
+    ```sh
+    pip install uv
+    uv venv
+    source .venv/bin/activate
+    uv pip install -e .
+    ```
+
+3. Create a .md file in the `docs/blog/posts` folder 
+4. Follow the following format for your post to ensure it builds on MkDocs
+    ```markdown
+    ---
+    date:
+    created: YYYY-MM-DD
+    authors:
+    - your_author_username
+    ---
+
+    # Title
+
+    Here is where your header (abstract) will be. This is what will appear on the blog post site
+
+    <!-- more --> # This is here to mark where the header ends and the content begins
+
+    Blog post content!
+
+    ```
+5. Add your name to the `docs/blog/.authors.yml` file, following the format of the page
+6. Run `mkdocs serve` in your terminal using the new env to test your blog post renders. Check for formatting
+7. Push your code to your fork, and create a pull request!
+  - In your pull request, select any of the editorial board to create your review. Two are required for the post to go live
+  - Once the post is reviewed, we'll merge your PR!

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-DeepGroundwater is looking to expand out of Beta development, and into a weekly-updated blog with  articles from both the Editoral board members, and scientific community. 
+DeepGroundwater is looking to expand out of Beta development, and into a consistently-updated blog with  articles from both the Editoral board members, and scientific community. 
 
 ## Features
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -1,17 +1,16 @@
 # Roadmap
 
-DeepGroundwater is looking to expand out of Beta development, and into a weekly-updated blog with  articles from both the board members, and scientific community. 
+DeepGroundwater is looking to expand out of Beta development, and into a weekly-updated blog with  articles from both the Editoral board members, and scientific community. 
 
 ## Features
 
 Below are ideas we are pursuing at DeepGroundwater to make the user, and research sharing, experience better:
 
-
 - [ ] Zenodo API Tools
 - [ ] arXiv API Tools
 - [ ] s3 API Tools 
 - [ ] Dockerization tutorials for complex apps
-- [ ] Data Catalogs for dataset management
+- [ ] Reference materials for storing dataset information
 
 If you're interested in tackling these ideas, feel free to open an issue in our GitHub page.
 


### PR DESCRIPTION
Addressing issue #11, and adding a quick walkthrough for someone making their first blog post. Also changed one of the research goals in the readme to be more specific.

<img width="874" alt="image" src="https://github.com/user-attachments/assets/eedc9acc-d1a0-48b3-ac78-4a009c79bf40" />

See `index.md` for changes.